### PR TITLE
Drivertest

### DIFF
--- a/docker/fc28/kvm-setup.sh
+++ b/docker/fc28/kvm-setup.sh
@@ -77,3 +77,21 @@ echo allow br0 >> /etc/qemu/bridge.conf
 # Avoid writing hwdb.bin on boot
 systemd-hwdb update --usr
 rm -f /etc/udev/hwdb.bin
+
+# See /auto/net_linux_verification/tools/ver_ansible/roles/verification_apps_playbook.yml
+# For drivertest, maybe we should build the exact versions they want..
+mkdir -p /opt/verutils/bin/
+
+ln -sf /usr/sbin/ptp4l /opt/verutils/bin/ptp4l
+ln -sf /usr/sbin/hwstamp_ctl /opt/verutils/bin/hwstamp_ctl
+
+ln -sf /usr/bin/iperf /opt/verutils/bin/iperf
+ln -sf /usr/sbin/ip /opt/verutils/bin/ip
+ln -sf /usr/sbin/rdma /opt/verutils/bin/rdma
+ln -sf /usr/sbin/devlink /opt/verutils/bin/devlink
+
+ln -sf /usr/bin/netserver /opt/verutils/bin/netserver
+ln -sf /usr/bin/netperf /opt/verutils/bin/netperf
+ln -sf /usr/bin/iperf3 /opt/verutils/bin/iperf3
+
+ln -sf /usr/sbin/ethtool /opt/verutils/bin/ethtool

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -5,6 +5,7 @@ COPY --from=local_mkt/support_simx:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rp
 COPY --from=local_mkt/support_pyverbs:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pypacket:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pcapy:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_netperf:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -8,6 +8,7 @@ COPY --from=local_mkt/support_pcapy:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/r
 COPY --from=local_mkt/support_netperf:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_ame:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_mft:fc28 /opt/mft/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_drivertest:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \
@@ -23,6 +24,7 @@ RUN \
     echo Israel/Jerusalem > /etc/timezone && \
     echo mellanox.com > /etc/mailname && \
     dnf install -y \
+    PyQt4 \
     bash-completion \
     bzip2 \
     ca-certificates \
@@ -37,10 +39,14 @@ RUN \
     iproute \
     kmod \
     less \
+    linuxptp \
+    iperf \
+    iperf3 \
     lsof \
     man \
     nano \
     net-tools \
+    opensm \
     openssh-server \
     pciutils \
     'perl(File::Basename)' \
@@ -51,6 +57,12 @@ RUN \
     psmisc \
     python-argcomplete \
     python2 \
+    python2-ipaddr \
+    python2-netaddr \
+    python2-netifaces \
+    python2-paramiko \
+    python2-pathlib2 \
+    python2-pyyaml \
     python3 \
     python3-argcomplete \
     qemu-kvm \
@@ -59,6 +71,7 @@ RUN \
     strace \
     sudo \
     tcpdump \
+    traceroute \
     udev \
     unzip \
     valgrind \
@@ -66,6 +79,9 @@ RUN \
     && dnf clean dbcache packages
 
 COPY --from=rpms /opt/rpms /opt/rpms
+
+# FIXME: should run this via support as well
+RUN pip install python-redmine==2.0.2 plumbum==1.6.7
 
 ADD sshd_config ssh_host_rsa_key /etc/ssh/
 

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -4,6 +4,7 @@ COPY --from=local_mkt/support_rdma_core:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /o
 COPY --from=local_mkt/support_simx:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pyverbs:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pypacket:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_pcapy:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -6,6 +6,8 @@ COPY --from=local_mkt/support_pyverbs:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt
 COPY --from=local_mkt/support_pypacket:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pcapy:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_netperf:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_ame:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_mft:fc28 /opt/mft/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -3,6 +3,7 @@ FROM fedora:28 as rpms
 COPY --from=local_mkt/support_rdma_core:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_simx:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_pyverbs:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_pypacket:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \

--- a/docker/fc28/kvm.Dockerfile
+++ b/docker/fc28/kvm.Dockerfile
@@ -2,6 +2,7 @@ FROM fedora:28 as rpms
 
 COPY --from=local_mkt/support_rdma_core:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 COPY --from=local_mkt/support_simx:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
+COPY --from=local_mkt/support_pyverbs:fc28 /root/rpmbuild/RPMS/x86_64/*.rpm /opt/rpms/
 
 RUN rm -f \
    /opt/rpms/*debug*.rpm \

--- a/docker/fc28/support-ame.sh
+++ b/docker/fc28/support-ame.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# ---
+# nfs_files:
+#  /mswg/release/tools/a-me/a-me-1.0.119/python_libs/adb.py:
+#    dest: /opt/src/
+#  /mswg/release/tools/a-me/a-me-1.0.119/python_libs/cadb-2.7-64/cadb.so:
+#    dest: /opt/src/
+
+# This comes from http://l-gerrit.mtl.labs.mlnx:8080/tools/a-me but in a
+# bizzare twist the above depends on mft's source code too.
+
+# Hackity hack to get ditutils to build an extension module
+cat <<EOF > dummy.c
+int thingy(void) {return 0;}
+EOF
+
+cat <<EOF > setup.py
+from distutils.core import setup, Extension
+
+setup(name="adb",
+      version="1.0.119",
+      description="Mellanox AME tool",
+      url="http://l-gerrit.mtl.labs.mlnx:8080/tools/a-me",
+      ext_modules=[Extension('cadb', ['dummy.c'])],
+      py_modules=["adb"],
+)
+EOF
+
+cat <<EOF > adb.spec
+%global srcname adb
+%global debug_package %{nil}
+
+Name:           python2-%{srcname}
+Version:        1
+Release:        1%{?dist}
+Summary:        Python verbs
+License:        Proprietary
+
+BuildRequires:  python2-devel
+
+%description
+Python verbs
+
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+cat ./cadb.so > %{buildroot}/%{python2_sitearch}/cadb.so
+
+%files
+%{python2_sitearch}/*
+EOF
+
+rpmbuild --build-in-place -bb adb.spec

--- a/docker/fc28/support-drivertest.sh
+++ b/docker/fc28/support-drivertest.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ---
+# git_url: http://l-gerrit.mtl.labs.mlnx:8080/Linux_drivers_verification/drivertest
+# git_commit: rel-00_07_0038
+# image_files:
+#   local_mkt/support_rdma_core:fc28:
+#       dest: /opt/rdma-core/
+#       files:
+#          - /root/rpmbuild/RPMS/x86_64/*.rpm
+#   local_mkt/support_pyverbs:fc28:
+#       dest: /opt/rpms/
+#       files:
+#          - /root/rpmbuild/RPMS/x86_64/*.rpm
+#   local_mkt/support_pypacket:fc28:
+#       dest: /opt/rpms/
+#       files:
+#          - /root/rpmbuild/RPMS/x86_64/*.rpm
+#   local_mkt/support_pcapy:fc28:
+#       dest: /opt/rpms/
+#       files:
+#          - /root/rpmbuild/RPMS/x86_64/*.rpm
+
+rm -f /opt/rdma-core/*debug*.rpm /opt/rpms/*debug*.rpm
+rpm -U /opt/rdma-core/lib*.rpm /opt/rdma-core/ibacm*.rpm /opt/rdma-core/rdma-core*.rpm /opt/rpms/*.rpm
+
+# FIXME: Sigh, fix this in the drivertest git
+find . -type f | xargs chmod a-x
+
+cat <<EOF > drivertest.spec
+%global srcname drivertest
+%global debug_package %{nil}
+
+Name:           python2-%{srcname}
+Version:        1
+Release:        1%{?dist}
+Summary:        Mellanox Driver test
+License:        Proprietary
+
+Requires: python2-ipaddr
+Requires: python2-netaddr
+Requires: python2-netifaces
+Requires: python2-paramiko
+Requires: python2-pathlib2
+Requires: python2-pcapy >= 0.11.1
+Requires: python2-pypacket
+Requires: python2-pyverbs
+Requires: python2-pyyaml
+# FIXME: Requires: python2-plumbum
+Requires: PyQt4
+# FIXME: python-redmine
+
+BuildRequires: python2-pyverbs
+BuildRequires: python2-devel
+
+%description
+Driver test
+
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+PYTHONPATH=%{buildroot}/%{python2_sitearch} %{buildroot}/%{_bindir}/drivertest_gui --help
+PYTHONPATH=%{buildroot}/%{python2_sitearch} %{buildroot}/%{_bindir}/drivertest_terminal --help
+
+%files
+%{python2_sitearch}/*
+%{_bindir}/drivertest*
+EOF
+
+# FIXME: pythondistdeps does not work
+
+rpmbuild --build-in-place -bb drivertest.spec

--- a/docker/fc28/support-mft.sh
+++ b/docker/fc28/support-mft.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# ---
+# nfs_files:
+#  /mswg/release/mft/mft-4.11.0/mft-4.11.0-14/linux/mft-4.11.0-14-int/RPMS/mft-int-4.11.0-14.x86_64.rpm:
+#    dest: /opt/mft/
+#  /mswg/release/mft/mft-4.11.0/mft-4.11.0-14/linux/mft-4.11.0-14/RPMS/mft-4.11.0-14-x86_64-rpm.tgz:
+#    dest: /opt/mft/
+
+# Maybe we should build MFT, but it looks like another nutzo thing to build...
+ln /opt/mft/mft-4.11.0-14-x86_64-rpm/RPMS/mft-4.11.0-14.x86_64.rpm /opt/mft

--- a/docker/fc28/support-netperf.sh
+++ b/docker/fc28/support-netperf.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# ---
+# git_url: https://github.com/HewlettPackard/netperf.git
+# git_commit: netperf-2.7.0
+
+./autogen.sh
+# So strange, configure writes the spec file
+./configure
+sed -i -e 's|BuildRequires: texinfo, texinfo-tex||g' netperf.spec
+rpmbuild --build-in-place -bb netperf.spec

--- a/docker/fc28/support-pcapy.sh
+++ b/docker/fc28/support-pcapy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# ---
+# git_url: https://github.com/CoreSecurity/pcapy
+# git_commit: 0.11.4
+
+# Spec file from pcapy-0.11.4-3.fc29.src.rpm
+cat <<EOF > pcapy.spec
+Name:           pcapy
+Version:        0.11.4
+Release:        1%{?dist}
+Summary:        A Python interface to libpcap
+
+License:        ASL 1.1
+URL:            https://www.coresecurity.com/corelabs-research/open-source-tools/pcapy
+
+BuildRequires:  gcc-c++
+BuildRequires:  python2-devel
+BuildRequires:  libpcap-devel
+
+%description
+Pcapy is a Python extension module that interfaces with the libpcap
+packet capture library. Pcapy enables python scripts to capture packets
+on the network. Pcapy is highly effective when used in conjunction with 
+a packet-handling package such as Impacket, which is a collection of 
+Python classes for constructing and dissecting network packets.
+
+%package -n python2-pcapy
+Summary:        %{sum}
+
+%{?python_provide:%python_provide python2-pcapy}
+
+%description -n python2-pcapy
+Python2 package of pcapy.
+Pcapy is a Python extension module that interfaces with the libpcap
+packet capture library. Pcapy enables python scripts to capture packets
+on the network. Pcapy is highly effective when used in conjunction with
+a packet-handling package such as Impacket, which is a collection of
+Python classes for constructing and dissecting network packets.
+
+%prep
+%setup -q
+
+%build
+%py2_build
+
+#fix encodings
+sed -i 's/\r//' LICENSE
+sed -i 's/\r//' README
+sed -i 's/\r//' pcapy.html
+iconv -f IBM850 -t UTF8 pcapy.html > pcapy.html.tmp
+mv pcapy.html.tmp pcapy.html
+
+%install
+%py2_install
+
+rm -rf %{buildroot}/usr/tests
+rm -rf %{buildroot}/usr/share/doc/pcapy
+
+%files -n python2-pcapy
+%license LICENSE
+%doc README pcapy.html
+%{python2_sitearch}/*
+EOF
+
+rpmbuild --build-in-place -bb pcapy.spec

--- a/docker/fc28/support-pypacket.sh
+++ b/docker/fc28/support-pypacket.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ---
+# git_url: http://l-gerrit.mtl.labs.mlnx:8080/Linux_drivers_verification/pypacket
+# git_commit: 31ad42d2496a8cf24e6f655435af43870d48ca6f
+
+cat <<EOF > pypacket.spec
+%global srcname pypacket
+%global debug_package %{nil}
+
+Name:           python2-%{srcname}
+Version:        1
+Release:        1%{?dist}
+Summary:        Python verbs
+License:        Proprietary
+
+BuildRequires:  python2-devel
+
+%description
+Python verbs
+
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%files
+%{python2_sitelib}/*
+EOF
+
+rpmbuild --build-in-place -bb pypacket.spec

--- a/docker/fc28/support-pyverbs.sh
+++ b/docker/fc28/support-pyverbs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# ---
+# git_url: git@github.com:Mellanox/Pyverbs.git
+# git_commit: 2018.10.24
+# image_files:
+#   local_mkt/support_rdma_core:fc28:
+#       dest: /opt/rdma-core/
+#       files:
+#          - /root/rpmbuild/RPMS/x86_64/*.rpm
+
+rm -f /opt/rdma-core/*debug*.rpm
+rpm -U /opt/rdma-core/lib*.rpm /opt/rdma-core/ibacm*.rpm /opt/rdma-core/rdma-core*.rpm
+
+# FIXME: Sigh, fix this in pyverbs git
+sed --in-place -e 's/0xffffL/0xffff/g' pyverbs/examples/tm_pingpong.py
+
+cat <<EOF > pyverbs.spec
+%global srcname pyverbs
+%global debug_package %{nil}
+
+Name:           python2-%{srcname}
+Version:        1
+Release:        1%{?dist}
+Summary:        Python verbs
+License:        Proprietary
+
+BuildRequires:  python2-devel
+
+%description
+Python verbs
+
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%files
+%{python2_sitearch}/*
+EOF
+
+rpmbuild --build-in-place -bb pyverbs.spec

--- a/docker/fc28/support-rdma_core.sh
+++ b/docker/fc28/support-rdma_core.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ---
 # git_url: https://github.com/linux-rdma/rdma-core.git
-# git_commit: v20
+# git_commit: v21
 
 rpmbuild --build-in-place -bb redhat/rdma-core.spec

--- a/docker/fc28/support.Dockerfile
+++ b/docker/fc28/support.Dockerfile
@@ -1,6 +1,7 @@
 FROM fedora:28
 
 RUN dnf install -y \
+    PyQt4 \
     binutils \
     cmake \
     dracut \
@@ -32,6 +33,12 @@ RUN dnf install -y \
     python \
     python2-Cython \
     python2-devel \
+    python2-ipaddr \
+    python2-netaddr \
+    python2-netifaces \
+    python2-paramiko \
+    python2-pathlib2 \
+    python2-pyyaml \
     rpm-build \
     spice-protocol \
     spice-server-devel \
@@ -43,3 +50,6 @@ RUN dnf install -y \
     valgrind-devel \
     zlib-devel \
     && dnf clean dbcache packages
+
+# FIXME: should run this via support as well
+RUN pip install python-redmine==2.0.2 plumbum==1.6.7

--- a/docker/fc28/support.Dockerfile
+++ b/docker/fc28/support.Dockerfile
@@ -3,10 +3,12 @@ FROM fedora:28
 RUN dnf install -y \
     binutils \
     cmake \
+    dracut \
     findutils \
     gcc \
     git-core \
     glib2-devel \
+    kmod \
     libaio-devel \
     libattr-devel \
     libcap-devel \
@@ -26,6 +28,8 @@ RUN dnf install -y \
     pkgconfig \
     pulseaudio \
     python \
+    python2-Cython \
+    python2-devel \
     rpm-build \
     spice-protocol \
     spice-server-devel \

--- a/docker/fc28/support.Dockerfile
+++ b/docker/fc28/support.Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
     dracut \
     findutils \
     gcc \
+    gcc-c++ \
     git-core \
     glib2-devel \
     kmod \
@@ -15,6 +16,7 @@ RUN dnf install -y \
     libfdt-devel \
     libnl3-cli \
     libnl3-devel \
+    libpcap-devel \
     libseccomp-devel \
     libudev-devel \
     libusb-devel \

--- a/mkt
+++ b/mkt
@@ -12,10 +12,11 @@ import utils.cmdline
 import plugins
 
 cmd_modules = {
-    "cmd_setup",
+    "cmd_drivertest",
     "cmd_images",
-    "cmd_run",
     "cmd_make",
+    "cmd_run",
+    "cmd_setup",
 }
 
 if __name__ == "__main__":

--- a/plugins/cmd_drivertest.py
+++ b/plugins/cmd_drivertest.py
@@ -1,0 +1,142 @@
+"""Helper commands to run driver_test
+"""
+import os
+import utils
+from utils.docker import *
+from . import cmd_images
+from . import cmd_run
+
+
+def args_drvt_gui(parser):
+    section = utils.load_config_file()
+    parser.add_argument(
+        "--os",
+        action="store",
+        help="The OS image to get the GUI from",
+        choices=sorted(cmd_images.supported_os),
+        default=section.get('os', 'fc28'))
+
+    parser.add_argument(
+        "--topology_file",
+        action="store",
+        help="Pass through the topology_file argument to driver test",
+        default=None)
+
+    parser.add_argument(
+        "--result_path",
+        action="store",
+        help="Pass through the result_path argument to driver test",
+        default=None)
+
+    parser.add_argument(
+        "--devel",
+        action="store",
+        help=
+        "Setup the given one test source directory as the source code to run the GUI. The player will continue to use its own source code.",
+        default=None)
+
+    parser.add_argument(
+        "DRVT_ARGS", nargs="*", help="Arguments to pass to driver_test, place them after a --")
+
+
+def cmd_drvt_gui(args):
+    """Launch the driver_test GUI."""
+    mapdirs = cmd_run.DirList()
+    mapdirs.add("/tmp/.X11-unix")
+
+    if args.topology_file is not None:
+        fn = os.path.realpath(args.topology_file)
+        assert fn.endswith(".ini")
+        mapdirs.add(os.path.dirname(fn))
+        args.DRVT_ARGS = ["--topology_file", fn] + args.DRVT_ARGS
+
+    if args.result_path is not None:
+        fn = os.path.realpath(args.result_path)
+        assert os.path.isdir(args.result_path)
+        mapdirs.add(args.result_path)
+        args.DRVT_ARGS = ["--result_path", fn] + args.DRVT_ARGS
+
+    dargs = []
+    home = os.path.expanduser("~")
+    if args.devel:
+        assert os.path.isdir(args.devel)
+        assert os.path.isdir(os.path.join(args.devel,".git"))
+
+        dargs.extend([
+            "-v",
+            "%s:/usr/lib64/python2.7/site-packages/drivertest:ro" %
+            (os.path.join(args.devel,"drivertest"))
+        ])
+
+    if "DISPLAY" in os.environ:
+        dargs.extend(["-e","DISPLAY=%s" % (os.environ["DISPLAY"])])
+        xauth = os.path.join(home,".Xauthority")
+        if os.path.isfile(xauth):
+            dargs.extend(["-v","%s:%s:ro"%(xauth,xauth)])
+
+    docker_exec(["run"] + mapdirs.as_docker_bind() + dargs + [
+        "--rm",
+        "--tty",
+        "--interactive",
+        "--ipc=host",
+        "--net=host",
+        "--user",
+        "%d:%d"%(os.getuid(), os.getgid()),
+        "-e","HOME=%s"%(home),
+        make_image_name("kvm", args.os),
+        "/usr/bin/drivertest_gui",
+        "--without_install",
+    ] + args.DRVT_ARGS)
+
+
+def args_drvt(parser):
+    args_drvt_gui(parser)
+def cmd_drvt(args):
+    """Launch the driver_test terminal."""
+    mapdirs = cmd_run.DirList()
+
+    if args.topology_file is not None:
+        fn = os.path.realpath(args.topology_file)
+        assert fn.endswith(".ini")
+        mapdirs.add(os.path.dirname(fn))
+        args.DRVT_ARGS = ["--topology_file", fn] + args.DRVT_ARGS
+
+    if args.result_path is not None:
+        fn = os.path.realpath(args.result_path)
+        assert os.path.isdir(args.result_path)
+        mapdirs.add(args.result_path)
+        args.DRVT_ARGS = ["--result_path", fn] + args.DRVT_ARGS
+
+    dargs = []
+    home = os.path.expanduser("~")
+    if args.devel:
+        assert os.path.isdir(args.devel)
+        assert os.path.isdir(os.path.join(args.devel,".git"))
+
+        dargs.extend([
+            "-v",
+            "%s:/usr/lib64/python2.7/site-packages/drivertest:ro" %
+            (os.path.join(args.devel,"drivertest"))
+        ])
+
+    docker_exec(["run"] + mapdirs.as_docker_bind() + dargs + [
+        "--rm",
+        "--tty",
+        "--interactive",
+        "--net=host",
+        "--user",
+        "%d:%d"%(os.getuid(), os.getgid()),
+        "-e","HOME=%s"%(home),
+        make_image_name("kvm", args.os),
+        "/usr/bin/drivertest_terminal",
+        "--without_install",
+    ] + args.DRVT_ARGS)
+
+    # Useful sequences:
+
+# mkt drvt --topology_file `/bin/pwd`/test.ini --result_path `/bin/pwd` -- --random_file /usr/lib64/python2.7/site-packages/drivertest/keeps/ib/all.yaml
+
+# mkt drvt-gui --devel ~/mlx/onetest/ --topology_file ./test.ini -- --random_file /usr/lib64/python2.7/site-packages/onetest/DriVerTest/Keeps/IB/all.yaml
+# mkt drvt-gui --topology_file /tmp/test.ini --result_path /images/jgg/results -- --random_file /usr/lib64/python2.7/site-packages/onetest/DriVerTest/Keeps/IB/all.yaml --autopilot
+# mkt run mlx5_1 --dir ~ --dir /images/jgg/results
+# http://veristats.mellanox.com/veristats_home/dri_ver_test_custom_run_view//swgwork/jgg/results/3/


### PR DESCRIPTION
This adds enough stuff to the fc28 kvm image for all the driver tests commands to print their help texts. Basically this is all the python code it obviously depends on.

I haven't yet figured out how to run driver test, but this is a big step forward on that goal.

It looks like driver test will require --dir /mswg/ to run due to all the firmware data file dependencies, but that feels like it is manageable.