### PR TITLE
setup: Add support for multi-host environments

### DIFF
--- a/plugins/cmd_setup.py
+++ b/plugins/cmd_setup.py
@@ -5,6 +5,7 @@ import utils
 import platform
 import subprocess
 import shutil
+import tempfile
 
 def args_setup(parser):
     parser.add_argument(
@@ -138,3 +139,124 @@ def cmd_setup(args):
                 p.wait()
 
     print("Completed, PLEASE RESTART server")
+
+#--------------------------------------------------------------------------------------------------------
+def args_setup_master(parser):
+     parser.add_argument(
+        "hostnames",
+        nargs='+',
+        help="List of slaves to connect")
+     parser.add_argument(
+        "-y",
+        "--assume-yes",
+        dest="yes",
+        action="store_true",
+        help="Automatically answer yes for all questions",
+        default=False)
+     parser.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Remove existing directories",
+        default=False)
+     parser.add_argument(
+        "--export-only",
+        dest="export",
+        action="store_true",
+        help="Skip installation stage and update NFS shares only",
+        default=False)
+
+def cmd_setup_master(args):
+    ''' Setup proper master environment and export it to slaves '''
+    if not args.export:
+        cmd = ["mkt", "setup"]
+        if args.yes:
+            cmd.append("-y")
+        if args.force:
+            cmd.append("-f")
+
+        subprocess.call(cmd)
+
+    utils.init_config_file()
+    section = utils.load_config_file()
+
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write(open("/etc/exports").read())
+        for host in args.hostnames:
+            export = section['src'] + "\t" + \
+                     str(host) + "(ro,async,no_subtree_check,no_root_squash)" + \
+                     "\n" + section['logs'] + "\t" + \
+                     str(host) + "(rw,async,no_subtree_check,no_root_squash)" + "\n"
+            f.write(export)
+            f.flush()
+        subprocess.call(["sudo", "cp", f.name, "/etc/exports"])
+
+    subprocess.call(["sudo", "exportfs", "-r"])
+
+#--------------------------------------------------------------------------------------------------------
+def args_setup_slave(parser):
+     parser.add_argument(
+        "hostname",
+        nargs=1,
+        help="Master server to connect this slave")
+     parser.add_argument(
+        "-y",
+        "--assume-yes",
+        dest="yes",
+        action="store_true",
+        help="Automatically answer yes for all questions",
+        default=False)
+     parser.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        action="store_true",
+        help="Remove existing directories",
+        default=False)
+     parser.add_argument(
+        "--export-only",
+        dest="export",
+        action="store_true",
+        help="Skip installation stage and update NFS shares only",
+        default=False)
+
+def cmd_setup_slave(args):
+    ''' Setup proper slave environment and connect to master server '''
+    if not args.export:
+        cmd = ["mkt", "setup", "--no-dirs"]
+        if args.yes:
+            cmd.append("-y")
+        if args.force:
+            cmd.append("-f")
+
+        subprocess.call(cmd)
+
+    utils.init_config_file()
+    section = utils.load_config_file()
+
+    subprocess.call(["sudo", "mkdir", "-p", section['src']])
+    subprocess.call(["sudo", "chown", "-R", utils.username() + ":" + utils.group(), section['src']])
+    subprocess.call(["sudo", "mkdir", "-p", section['logs']])
+    subprocess.call(["sudo", "chown", "-R", utils.username() + ":" + utils.group(), section['logs']])
+
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write(open("/etc/fstab").read())
+        export = args.hostname[0] + ":" + \
+                section['src'][:-1] + "\t" + section['src'][:-1] + \
+                 "\t" + "nfs" + "\t" + "ro,nolock 0 0" + "\n" + \
+                 args.hostname[0] + ":" + \
+                 section['logs'][:-1] + "\t" + section['logs'][:-1] + \
+                 "\t" + "nfs" + "\t" + "rw,nolock 0 0" + "\n"
+        f.write(export)
+        f.flush()
+        subprocess.call(["sudo", "cp", f.name, "/etc/fstab"])
+
+    subprocess.call(["sudo", "mount", "-a", "-t", "nfs", "-o", "remount"])
+#--------------------------------------------------------------------------------------------------------
+def args_reconnect_slave(parser):
+    pass
+
+def cmd_reconnect_slave(args):
+    ''' Reconnect slave in case master was rebooted '''
+    subprocess.call(["sudo", "mount", "-a", "-t", "nfs", "-o", "remount"])


### PR DESCRIPTION
Introduce two new commands to setup master and slaves to support
multi-host environments setups.

Those commands are not intended to provide granular setup options
and in case someone needs it, he/she should consider to use "setup"
command directly.

It is useful for developers who have multiple servers connected
back-to-back as their main testing platforms.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>