### PR TITLE
run: Don't crash when dir is not set in the config

### DIFF
--- a/plugins/cmd_run.py
+++ b/plugins/cmd_run.py
@@ -328,7 +328,8 @@ def cmd_run(args):
 
     usr = pwd.getpwuid(os.getuid())
     args.dir.append(usr.pw_dir)
-    args.dir += section.get('dir', None).split()
+    if 'dir' in section:
+        args.dir += section['dir'].split()
     args.dir = list(set(args.dir))
 
     for I in args.dir:


### PR DESCRIPTION
The default config doesn't have dir set, so `section.get('dir', None)`
becomes None, and split is not applicable and leads to a crash:

```
Traceback (most recent call last):
  File ".../bin/mkt", line 22, in <module>
    utils.cmdline.main(cmd_modules, plugins)
  File ".../mkt/utils/cmdline.py", line 145, in main
    args.func(args)
  File ".../mkt/plugins/cmd_run.py", line 331, in cmd_run
    args.dir += section.get('dir', None).split()
AttributeError: 'NoneType' object has no attribute 'split'
```

Fix it by checking the existance of dir explcitly.

Signed-off-by: Maxim Mikityanskiy <maximmi@mellanox.com>