### PR TITLE
run: Provide log file for SimX debug

### DIFF
--- a/docs/mkt_run.1.md
+++ b/docs/mkt_run.1.md
@@ -125,6 +125,15 @@ avoids re-using addresses assigned to existing instances. Use **docker ps**
 and **docker kill** to manage running instances of **mkt run**, particularly
 if they have been backgrounded by a ssh connection drop.
 
+## SIMX DEBUG
+
+**mkt** runs over SimX are configured to produce /opt/simx/logs/simx-qemu.log
+file directly in the docker instance created by **mkt run**. By default this
+file is almost empty. In order to increase verbosity level and output more
+information, you are invited to add extra logger comands obtaied from SimX
+developers and put it into **set_simx_log()** function of **plugins/do-kvm.py"
+file.
+
 # MKT
 
 Part of the **mkt(1)** suite

--- a/plugins/do-kvm.py
+++ b/plugins/do-kvm.py
@@ -265,6 +265,20 @@ def set_loop_network(args):
         "user,hostfwd=tcp:127.0.0.1:4444-:22"
     ])
 
+def set_simx_log():
+    """Prepare simx log file."""
+
+    # Old SimX version relies on the fact that log file exists,
+    # create that file for them
+    subprocess.check_call(['mkdir', '-p', '/opt/simx/logs/'])
+    f = open('/opt/simx/logs/simx-qemu.log', 'w+')
+    f.close()
+
+    subprocess.check_call(['mkdir', '-p', '/opt/simx/cfg/'])
+    with open('/opt/simx/cfg/simx-qemu.cfg', 'a+') as f:
+         f.write('[logger]\n')
+         f.write('log_file_redirection = /opt/simx/logs/simx-qemu.log\n')
+
 def set_simx_network(simx):
     """Setup options to start a simx card"""
     to_simx_device = { 'cx4' : 'connectx4',
@@ -414,6 +428,7 @@ set_vfio(args)
 
 if args.simx:
     cmd = ["/opt/simx/bin/qemu-system-x86_64"]
+    set_simx_log()
     set_simx_network(args.simx)
 else:
     cmd = ["qemu-system-x86_64"]


### PR DESCRIPTION
Create special file to log SimX activities, this is needed to debug SimX.

Reported-by: Aya Levin <ayal@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>