### PR TITLE
fc29: Fix sftp support in sshd

### DIFF
--- a/docker/fc29/sshd_config
+++ b/docker/fc29/sshd_config
@@ -62,7 +62,7 @@ TCPKeepAlive yes
 # Allow client to pass locale environment variables
 AcceptEnv LANG LC_*
 
-Subsystem sftp /usr/lib/openssh/sftp-server
+Subsystem sftp /usr/libexec/openssh/sftp-server
 
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will


### PR DESCRIPTION
The config file was copied from debian where the path to sftp
is different. Fedora puts the exec in libexec.

Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>