### PR TITLE
run: Execute custom boot script

### DIFF
--- a/docs/example.mkt
+++ b/docs/example.mkt
@@ -23,6 +23,7 @@ dir = /path/to/first/dir path/to/second/dir /path/to/third/dir
 [cx5-ib]
 # List of PICs to connect to this container
 pci = 0000:05:00.0 0000:88:00.0
+boot_script = /labhome/leonro/ib_bootup_script
 [simx]
 # PCI supports simx-aware names, supported options
 # are: cx4-ib, cx4-eth, cib-ib, cx5-ib, cx5-eth, cx4lx-eth, cx6-ib, cx6-eth


### PR DESCRIPTION
Add new command line option --boot-script which receives path
to custom script. That script will be executed prior to providing
serial console to the user.

The same option is named "boot_script" and can be set in image sections
of configuration file.

Script is needed to be executable (+x bit) and is expected to have
shebang (#!...) line at the beginning.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>