### PR TITLE
run: Open SSH connection for already present PCI container

### DIFF
--- a/utils/docker.py
+++ b/utils/docker.py
@@ -43,8 +43,8 @@ def docker_output(args, mode=None):
         raise ValueError("Bad mode %r" % (mode))
 
 
-def docker_get_containers(name):
+def docker_get_containers(label):
     containers = docker_output(
-        ["ps", "-a", "-q", "--filter",
-         "name=%s" % (name)], mode="lines")
+        ["ps", "--format", '"{{.Names}}"', "--filter",
+         "label=%s" % (label)], mode="lines")
     return containers


### PR DESCRIPTION
The need to bind real devices while executing new docker container
causes to difference in "mkt run" behavior between real devices and
virtualized ones.

Consecutive runs of "mkt run" for virtualized devices create new
container every time, while "mkt run" over real devices throws
an error to indicate that device is busy.

In this change, we implemented scheme that "mkt run" over real devices
will open ssh connection to that docker instead of attempting to run
container.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>