### PR TITLE
mkt: Add an option to use different kernels for different images

### DIFF
--- a/docs/example.mkt
+++ b/docs/example.mkt
@@ -25,6 +25,7 @@ dir = /path/to/first/dir path/to/second/dir /path/to/third/dir
 # List of PICs to connect to this container
 pci = 0000:05:00.0 0000:88:00.0
 boot_script = /labhome/leonro/ib_bootup_script
+kernel = /path/to/different/kernel/
 [simx]
 # PCI supports simx-aware names, supported options
 # are: cx4-ib, cx4-eth, cib-ib, cx5-ib, cx5-eth, cx4lx-eth, cx6-ib, cx6-eth

--- a/plugins/cmd_run.py
+++ b/plugins/cmd_run.py
@@ -290,7 +290,7 @@ def args_run(parser):
     kernel.add_argument(
         '--kernel',
         help="Path to the top of a compiled kernel source tree to boot",
-        default=section.get('kernel', None))
+        default=None)
     kernel.add_argument(
         '--kernel-rpm', help="Path to a kernel RPM to boot", default=None)
 
@@ -354,6 +354,13 @@ def cmd_run(args):
     if args.image:
         pci = utils.get_images(args.image)['pci']
         s = pci.split()
+        try:
+            args.kernel = utils.get_images(args.image)['kernel']
+        except KeyError:
+            pass
+
+    if args.kernel is None:
+        args.kernel = section.get('kernel', None)
 
     union = set(get_simx_rdma_devices()).union(
         set(get_pci_rdma_devices().keys())).union(


### PR DESCRIPTION
Add a new option "kernel" under [images] section to allow override
the global kernel location. It can be very useful while working
with git worktree instead of branches, and images connected to
those worktrees.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>