### PR TITLE
build: Don't hardcode build GID

### DIFF
--- a/plugins/cmd_build.py
+++ b/plugins/cmd_build.py
@@ -49,7 +49,7 @@ def cmd_build(args):
     build.pickle['shell'] = args.run_shell
     build.pickle["passwd"] = "%s:x:%s:%s:%s:%s:/bin/bash" % (username(),
                 os.getuid(), os.getgid(), username(), os.getenv("HOME"))
-    build.pickle["group"] = "%s:x:101:" % (group())
+    build.pickle["group"] = "%s:x:%s:" % (group(), os.getgid())
     build.pickle["uid"] = int(os.getuid())
     build.pickle["gid"] = int(os.getgid())
     build.pickle["home"] = os.getenv("HOME")


### PR DESCRIPTION
Build on the unmanaged by Mellanox machine produces the following warning:
➜  kernel git:(rdma-next) mkt build --run-shell
/usr/bin/id: cannot find name for group ID 1000

The reason to it, assumption that user's GID is equal to 101, which is wrong.

Fixes: d600632914bb ("build: Convert from inline commands to general build script")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>