### PR TITLE
simx: Add multiport device support

### DIFF
--- a/docs/example.mkt
+++ b/docs/example.mkt
@@ -40,6 +40,11 @@ pci = rxe-eth0
 pci = cx5-eth
 num_of_vfs = 7
 
+[simx-multi-port]
+# Simulate multiport device
+pci = cx5-eth
+num_ports = 2
+
 [custom-qemu]
 pci = cx4-ib 0000:05:00.0
 # Use precompiled version of QEMU

--- a/plugins/cmd_run.py
+++ b/plugins/cmd_run.py
@@ -242,6 +242,10 @@ def get_pickle(args, vm_addr):
             p["num_of_vfs"] = utils.get_images(args.image)['num_of_vfs']
         except KeyError:
             pass
+        try:
+            p["num_ports"] = utils.get_images(args.image)['num_ports']
+        except KeyError:
+            pass
 
     if args.custom_qemu:
         p["custom_qemu"] = args.custom_qemu

--- a/plugins/do-kvm.py
+++ b/plugins/do-kvm.py
@@ -359,6 +359,7 @@ def set_simx_network(simx):
         f.write('[General Device Capabilities]\n')
         f.write('driver_version = false\n')
         f.write('query_driver_version = false\n')
+        f.write('num_ports = %s\n' % (args.num_ports))
 
         idx = 1
         eth_sriov = False
@@ -467,6 +468,7 @@ def setup_from_pickle(args, pickle_params):
     args.num_of_vfs = p.get("num_of_vfs", 0)
     args.custom_qemu = p.get("custom_qemu", None)
     args.gdbserver = p.get("gdbserver", None)
+    args.num_ports = p.get("num_ports", 1)
 
 parser = argparse.ArgumentParser(
     description='Launch kvm using the filesystem from the container')


### PR DESCRIPTION
Allow simulation of multiport devices by setting "num_ports" inside
config image section.

[leonro@mtr-leonro ~]$ rdma link
0/1: rocep0s12/1: state ACTIVE physical_state LINK_UP netdev eth1
0/2: rocep0s12/2: state DOWN physical_state DISABLED
[leonro@mtr-leonro ~]$ rdma dev
0: rocep0s12: node_type ca fw 4.4.9999 node_guid 5254:00c0:fe12:3455
   sys_image_guid 5254:00c0:fe12:3455

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>