### PR TITLE
Fix basic setup to force RPM installation

### DIFF
--- a/docker/fc34/basic-setup.sh
+++ b/docker/fc34/basic-setup.sh
@@ -69,4 +69,4 @@ cat <<EOF > /etc/sysctl.d/hugepages.conf
 vm.nr_hugepages=2
 EOF
 
-rpm -U /opt/rpms/*.rpm
+rpm -U --force /opt/rpms/*.rpm


### PR DESCRIPTION
I keep getting the following error on various platforms.
```
 ---> 36fcdbcc9b14
Step 9/11 : ADD sshd_config ssh_host_rsa_key /etc/ssh/
 ---> Using cache
 ---> 3dffc7c5da74
Step 10/11 : ADD basic-setup.sh kvm-setup.sh /root/
 ---> 39d5b0df245a
Step 11/11 : RUN /root/basic-setup.sh && /root/kvm-setup.sh
 ---> Running in c67ebf8063aa
Removed /etc/systemd/system/multi-user.target.wants/sshd.service.
	package libibverbs-35.0-1.fc34.x86_64 is already installed
	package librdmacm-35.0-1.fc34.x86_64 is already installed
	package libibumad-35.0-1.fc34.x86_64 is already installed
	package infiniband-diags-35.0-1.fc34.x86_64 is already installed
	package rdma-core-35.0-1.fc34.x86_64 is already installed
The command '/bin/sh -c /root/basic-setup.sh && /root/kvm-setup.sh' returned a non-zero code: 16
Traceback (most recent call last):
  File "/images/artemp/mkt/./mkt", line 25, in <module>
    utils.cmdline.main(cmd_modules, plugins)
  File "/images/artemp/mkt/utils/cmdline.py", line 147, in main
    args.func(args)
  File "/images/artemp/mkt/plugins/cmd_images.py", line 312, in cmd_images
    docker_call(cmd + ["-t", image, "-f", dockerfn, "."])
  File "/images/artemp/mkt/utils/docker.py", line 20, in docker_call
    return subprocess.check_call([
  File "/usr/lib64/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['sudo', 'docker', 'build', '-t', 'harbor.mellanox.com/mkt/kvm:fc34', '-f', 'kvm.Dockerfile', '.']' returned non-zero exit status 16.
```

This fix solves my issue.