### PR TITLE
docker: Fix same declaration of rdma-core version as in base image

### DIFF
--- a/docker/fc34/support-rdma_core.sh
+++ b/docker/fc34/support-rdma_core.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ---
 # git_url: https://github.com/linux-rdma/rdma-core.git
-# git_commit: e29a698e99028e9a092bb00c03ee4bfa31ae0cf3
+# git_commit: 559083a154af62e02815969c337e90ef4c3cd173
 
 rpmbuild --build-in-place -bb redhat/rdma-core.spec --with pyverbs

--- a/plugins/cmd_build.py
+++ b/plugins/cmd_build.py
@@ -28,6 +28,8 @@ def args_build(parser):
         action="store_true",
         default=False,
         help="Install kernel headers (used in custom build target)")
+    parser.add_argument(
+        '--dir', action="append", help="Other paths to map", default=[])
 
 def cmd_build(args):
     """Smart build."""
@@ -42,9 +44,13 @@ def cmd_build(args):
     build = Build(args.project)
 
     recipe_dir = None
+    mapdirs = utils.DirList()
+    for I in args.dir:
+        mapdirs.add(I)
+
     if args.build_recipe is not None:
         args.build_recipe = os.path.realpath(args.build_recipe)
-        recipe_dir = os.path.dirname(args.build_recipe)
+        mapdirs.add(os.path.dirname(args.build_recipe))
 
     build.pickle['shell'] = args.run_shell
     build.pickle["passwd"] = "%s:x:%s:%s:%s:%s:/bin/bash" % (username(),
@@ -60,4 +66,4 @@ def cmd_build(args):
         build.pickle['kernel'] = section.get('kernel', None)
 
     do_cmd = ["python3", "/plugins/do-build.py"]
-    docker_exec(["run"] + build.run_build_cmd(cmd_images.default_os, recipe_dir) + do_cmd)
+    docker_exec(["run"] + build.run_build_cmd(cmd_images.default_os, mapdirs) + do_cmd)

--- a/plugins/cmd_run.py
+++ b/plugins/cmd_run.py
@@ -16,40 +16,10 @@ import collections
 import random
 from utils.docker import *
 from utils.cmdline import *
+from utils.dirs import *
 from . import cmd_images
 
 VM_Addr = collections.namedtuple("VM_Addr", "hostname ip mac")
-
-class DirList(object):
-    def __init__(self):
-        self.list = set()
-
-    def add(self, dfn):
-        """Maintain a list of directories such that there are no subdirectories of
-        other elements in the list."""
-        if isinstance(dfn, bytes):
-            dfn = dfn.decode()
-        while dfn[-1] == '/':
-            dfn = dfn[:-1]
-
-        dfn = os.path.realpath(dfn)
-
-        torm = set()
-        for I in self.list:
-            if dfn.startswith(I):
-                return
-            if I.startswith(dfn):
-                torm.add(I)
-        self.list.difference_update(torm)
-        self.list.add(dfn)
-
-    def as_docker_bind(self):
-        res = []
-        for I in sorted(self.list):
-            res.append("-v")
-            res.append("%s:%s:Z" % (I, I))
-        return res
-
 
 def match_modalias(modalias):
     """Detect Mellanox devices that we want to pass through"""
@@ -423,7 +393,7 @@ def cmd_run(args):
             os.path.join(os.path.dirname(__file__), "vfio.py")
         ] + ["--pci=%s" % (I) for I in args.pci])
 
-    mapdirs = DirList()
+    mapdirs = utils.DirList()
     if args.kernel_rpm is not None:
         args.kernel_rpm = os.path.realpath(args.kernel_rpm)
         if not os.path.isfile(args.kernel_rpm):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,6 @@
 from .cmdline import get_internal_fn, query_yes_no
 from .config import load_config_file, username, group, init_config_file, get_images, init_log_dir
+from .dirs import DirList
 
 __all__ = [
     "get_internal_fn",
@@ -10,4 +11,5 @@ __all__ = [
     "init_config_file",
     "init_log_dir",
     "get_images",
+    "DirList"
 ]

--- a/utils/dirs.py
+++ b/utils/dirs.py
@@ -1,0 +1,33 @@
+"""Directory logic
+"""
+import os
+
+class DirList(object):
+    def __init__(self):
+        self.list = set()
+
+    def add(self, dfn):
+        """Maintain a list of directories such that there are no subdirectories of
+        other elements in the list."""
+        if isinstance(dfn, bytes):
+            dfn = dfn.decode()
+        while dfn[-1] == '/':
+            dfn = dfn[:-1]
+
+        dfn = os.path.realpath(dfn)
+
+        torm = set()
+        for I in self.list:
+            if dfn.startswith(I):
+                return
+            if I.startswith(dfn):
+                torm.add(I)
+        self.list.difference_update(torm)
+        self.list.add(dfn)
+
+    def as_docker_bind(self):
+        res = []
+        for I in sorted(self.list):
+            res.append("-v")
+            res.append("%s:%s:Z" % (I, I))
+        return res

--- a/utils/dirs.py
+++ b/utils/dirs.py
@@ -25,9 +25,12 @@ class DirList(object):
         self.list.difference_update(torm)
         self.list.add(dfn)
 
-    def as_docker_bind(self):
+    def as_docker_bind(self, rw=False):
         res = []
         for I in sorted(self.list):
             res.append("-v")
-            res.append("%s:%s:Z" % (I, I))
+            if rw:
+                res.append("%s:%s:rw,Z" % (I, I))
+            else:
+                res.append("%s:%s:Z" % (I, I))
         return res


### PR DESCRIPTION
Both default rdma-core version that comes with FC34 and declared in
support-rdma_core were v35. This caused to the following error during
image rebuilt:

 ---> 36fcdbcc9b14
Step 9/11 : ADD sshd_config ssh_host_rsa_key /etc/ssh/
 ---> Using cache
 ---> 3dffc7c5da74
Step 10/11 : ADD basic-setup.sh kvm-setup.sh /root/
 ---> 39d5b0df245a
Step 11/11 : RUN /root/basic-setup.sh && /root/kvm-setup.sh
 ---> Running in c67ebf8063aa
Removed /etc/systemd/system/multi-user.target.wants/sshd.service.
	package libibverbs-35.0-1.fc34.x86_64 is already installed
	package librdmacm-35.0-1.fc34.x86_64 is already installed
	package libibumad-35.0-1.fc34.x86_64 is already installed
	package infiniband-diags-35.0-1.fc34.x86_64 is already installed
	package rdma-core-35.0-1.fc34.x86_64 is already installed
The command '/bin/sh -c /root/basic-setup.sh && /root/kvm-setup.sh' returned a non-zero code: 16
Traceback (most recent call last):
  File "/images/artemp/mkt/./mkt", line 25, in <module>
    utils.cmdline.main(cmd_modules, plugins)
  File "/images/artemp/mkt/utils/cmdline.py", line 147, in main
    args.func(args)
  File "/images/artemp/mkt/plugins/cmd_images.py", line 312, in cmd_images
    docker_call(cmd + ["-t", image, "-f", dockerfn, "."])
  File "/images/artemp/mkt/utils/docker.py", line 20, in docker_call
    return subprocess.check_call([
  File "/usr/lib64/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['sudo', 'docker', 'build', '-t', 'harbor.mellanox.com/mkt/kvm:fc34', '-f', 'kvm.Dockerfile', '.']' returned non-zero exit status 16.

As a solution, use v36 version in support script.

Fixes: e355a573d17a ("docker: Upgrade all tools and OS")
Reported-by: Artem Polyakov <artemp@nvidia.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>