### PR TITLE
run: Set reliable clocksource for the nested VM

### DIFF
--- a/plugins/do-kvm.py
+++ b/plugins/do-kvm.py
@@ -225,6 +225,8 @@ earlyprintk=serial,ttyS0,115200 console=hvc0 \
 noibrs noibpb nopti nospectre_v2 nospectre_v1 \
 l1tf=off nospec_store_bypass_disable no_stf_barrier \
 mds=off mitigations=off'
+    if args.inside_mkt:
+        cmdline = cmdline + ' clocksource=acpi_pm'
 
     if not args.inside_mkt:
         bzimage = os.path.join(tree, "arch/x86/boot/bzImage")


### PR DESCRIPTION
The second QEMU (L1) throws the following errors during the boot:

 clocksource: timekeeping watchdog on CPU6: hpet read-back delay of 5252e
 tsc: Marking TSC unstable due to clocksource watchdog
 TSC found unstable after boot, most likely due to broken BIOS. Use 'tsc=unstable'.
 sched_clock: Marking unstable (215589163972, -47156905)<-(216119104390, -577097322)
 clocksource: Checking clocksource tsc synchronization from CPU 0 to CPUs 1-3,7.
 clocksource: Switched to clocksource hpet

So instead of trying to find the root cause, switch to acpi_pm clocksource
from the beginning.

Signed-off-by: Leon Romanovsky <leonro@nvidia.com>