### PR TITLE
kvm: Use qemu-bridge-helper when linking virbr0 to SimX netdev

### DIFF
--- a/plugins/cmd_run.py
+++ b/plugins/cmd_run.py
@@ -48,7 +48,7 @@ def build_dirlist(args, section):
 
 def match_modalias(modalias):
     """Detect Mellanox devices that we want to pass through"""
-    # Fom /lib/modules/4.18.rc1/modules.alias
+    # From /lib/modules/4.18.rc1/modules.alias
     matches = [
         "pci:v000015B3d0000A2DCsv*sd*bc*sc*i*",
         "pci:v000015B3d0000A2D6sv*sd*bc*sc*i*",

--- a/plugins/do-kvm.py
+++ b/plugins/do-kvm.py
@@ -441,7 +441,7 @@ def set_simx_network(simx):
                 set_sriov_vfs(args, idx, mode)
 
             if have_virbr:
-                qemu_args["-netdev"].add("bridge,br=virbr0,id=net%d" %(idx))
+                qemu_args["-netdev"].add("bridge,br=virbr0,id=net%d,helper=/usr/libexec/qemu-bridge-helper" %(idx))
                 devargs += ',netdev=net%d' %(idx)
 
             qemu_args["-device"].append(devargs)


### PR DESCRIPTION
QEMU fails to bring up netdev/startup without the use of qemu-bridge-helper.